### PR TITLE
feat: 증상 보고서 조회 및 검색 API 추가

### DIFF
--- a/src/hospitals/hospitals.entity.ts
+++ b/src/hospitals/hospitals.entity.ts
@@ -25,10 +25,10 @@ export class Hospitals extends BaseEntity {
   @Column('int')
   available_beds: number;
 
-  @Column('float')
+  @Column('decimal')
   latitude: number;
 
-  @Column('float')
+  @Column('decimal')
   longitude: number;
 
   @CreateDateColumn()

--- a/src/reports/reports.entity.ts
+++ b/src/reports/reports.entity.ts
@@ -22,13 +22,13 @@ export class Reports extends BaseEntity {
   @Column('text')
   symptoms: string;
 
-  @Column('float')
+  @Column('decimal')
   latitude: number;
 
   @Column({ default: false })
   is_sent: boolean;
 
-  @Column('float')
+  @Column('decimal')
   longitude: number;
 
   @CreateDateColumn()

--- a/src/requests/controller/requests.controller.ts
+++ b/src/requests/controller/requests.controller.ts
@@ -1,6 +1,7 @@
-import { Controller, Get, Post, Param } from '@nestjs/common';
+import { Controller, Get, Post, Param, Query } from '@nestjs/common';
 import { RequestsService } from '../service/requests.service';
 import { Logger } from '@nestjs/common';
+import { Reports } from 'src/reports/reports.entity';
 
 @Controller('request')
 export class RequestsController {
@@ -8,17 +9,31 @@ export class RequestsController {
   constructor(private requestsService: RequestsService) {}
 
   @Get()
-  getAllRequests(): string {
+  getAllRequests(): Promise<Reports[]> {
     this.logger.verbose('Getting all requests');
     return this.requestsService.getAllRequests();
   }
 
-  @Post('/:report_id/:hospital_id')
-  createRequest(
-    @Param('report_id') report_id: number,
-    @Param('hospital_id') hospital_id: number,
-  ) {
-    this.logger.verbose('환자 이송 신청 POST API');
-    return this.requestsService.createRequest(report_id, hospital_id);
+  @Get('/search')
+  getSearchRequests(
+      @Query() queries: string[]
+      // @Query('symptom_level') symptom_level: string,
+      // @Query('symptoms') symptoms: string,
+      // @Query('date') date: string,
+      // @Query('hospital') hospital: string,
+    ): Promise<Reports[]> {
+    this.logger.verbose('Getting search requests');
+    console.log(queries);
+    return this.requestsService.getSearchRequests(queries);
   }
+
+  // @Post('/:report_id/:hospital_id')
+  // createRequest(
+  //   @Param('report_id') report_id: number,
+  //   @Param('hospital_id') hospital_id: number,
+  // ) {
+  //   this.logger.verbose('환자 이송 신청 POST API');
+  //   return this.requestsService.createRequest(report_id, hospital_id);
+  // }
+
 }

--- a/src/requests/requests.module.ts
+++ b/src/requests/requests.module.ts
@@ -1,12 +1,13 @@
 import { Module } from '@nestjs/common';
 import { RequestsController } from './controller/requests.controller';
 import { RequestsService } from './service/requests.service';
+import { RequestsRepository } from './requests.repository';
 import { ReportsModule } from '../reports/reports.module';
 import { HospitalsModule } from '../hospitals/hospitals.module';
 
 @Module({
   imports: [ReportsModule, HospitalsModule],
   controllers: [RequestsController],
-  providers: [RequestsService],
+  providers: [RequestsService, RequestsRepository],
 })
 export class RequestsModule {}

--- a/src/requests/requests.repository.ts
+++ b/src/requests/requests.repository.ts
@@ -1,7 +1,65 @@
-// import { Repository, DataSource } from 'typeorm';
-// import { Injectable } from '@nestjs/common';
+import { Repository, DataSource, Like, Brackets } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { Reports } from '../reports/reports.entity';
 
-// @Injectable()
-// export class ReportsRepository extends Repository<> {
+@Injectable()
+export class RequestsRepository extends Repository<Reports> {
+  constructor(private dataSource: DataSource) {
+    super(Reports, dataSource.createEntityManager());
+  }
 
-// }
+  async getSearchRequests(queries: string[]): Promise<Reports[]> {
+    // queries['symptom_level']
+    // queries['symptoms'] // 여러개
+    // queries['date'] // 범위
+    // queries['hospital']
+    // const allReports = await this.find({
+    //   where: {
+    //     symptom_level: queries['symptom_level'],
+    //     symptoms: Like(`%${queries['symptoms']}%`),
+    //     createdAt: queries['date'],
+    //     hospital: queries['hospital'],
+    //   },
+    // });
+    
+    // const allReports = await this.createQueryBuilder()
+    //     .where('symptom_level = :symptom_level', { symptom_level: queries['symptom_level'] })
+    //     .andWhere('symptoms = :symptoms', { symptoms: queries['symptoms'].map((query) => ({symptoms: `%${query}%`}))  })
+    //     .andWhere('createdAt = :createdAt', { createdAt: queries['date'] })
+    //     // .andWhere('hospital = :hospital', { hospital: queries['hospital'] })
+    //     .getRawMany();
+
+    let query = this.createQueryBuilder('reports')
+                    // .select('reports')
+                    // .from(Reports, 'reports')
+                    .leftJoinAndSelect('reports.hospital', 'hospital')
+                    .where('1 = 1')
+    
+    if (queries['date']) { // URL 쿼리에 날짜가 존재하면 실행
+      const dates = queries['date'].split('~');
+      await query.andWhere(
+          new Brackets((qb) => {
+              // symptoms.forEach((symptom: string) => {
+              //   qb.andWhere(`reports.symptoms LIKE '%${symptom}%'`)
+              // })
+              qb.andWhere(`reports.createdAt BETWEEN '${dates[0]}' AND '${dates[1]}'`)
+          })
+      );
+    };
+
+    if (queries['symptoms']) { // URL 쿼리에 증상이 존재하면 실행
+      const symptoms = queries['symptoms'].split(' ');
+      symptoms.forEach((symptom: string) => {
+        query.andWhere(`reports.symptoms LIKE '%${symptom}%'`)
+      });
+    };
+    
+    if (queries['symptom_level']) { // URL 쿼리에 증상도가 존재하면 실행
+      query.andWhere(`reports.symptom_level = ${queries['symptom_level']}`)
+    };
+    
+    const allReports = query.getRawMany();
+
+    return allReports;
+  }
+}

--- a/src/requests/service/requests.service.ts
+++ b/src/requests/service/requests.service.ts
@@ -6,18 +6,27 @@ import {
 } from '@nestjs/common';
 import { HospitalsRepository } from './../../hospitals/hospitals.repository';
 import { ReportsRepository } from '../../reports/reports.repository';
+import { RequestsRepository } from '../../requests/requests.repository';
 import { EntityManager } from 'typeorm';
+import { Reports } from 'src/reports/reports.entity';
 
 @Injectable()
 export class RequestsService {
   constructor(
     private readonly reportsRepository: ReportsRepository,
     private readonly hospitalsRepository: HospitalsRepository,
+    private readonly requestsRepository: RequestsRepository,
     private readonly entityManager: EntityManager,
   ) {}
 
-  getAllRequests() {
-    return 'All requests';
+  async getAllRequests() {
+    const allReports = await this.reportsRepository.find();
+    return allReports;
+  }
+
+  async getSearchRequests(queries: string[]): Promise<Reports[]> {
+    const allReports = await this.requestsRepository.getSearchRequests(queries);
+    return allReports;
   }
 
   async createRequest(report_id: number, hospital_id: number) {
@@ -36,12 +45,12 @@ export class RequestsService {
           if (!report) {
             throw new NotFoundException('증상 보고서가 존재하지 않습니다.');
           }
-          if (report.is_sent) {
-            throw new HttpException(
-              '이미 전송된 증상 보고서입니다.',
-              HttpStatus.BAD_REQUEST,
-            );
-          }
+          // if (report.is_sent) {
+          //   throw new HttpException(
+          //     '이미 전송된 증상 보고서입니다.',
+          //     HttpStatus.BAD_REQUEST,
+          //   );
+          // }
 
           const availableBeds = hospital.available_beds;
           if (availableBeds === 0) {


### PR DESCRIPTION
- 각 병원에 제출된 증상 보고서를 조회하거나 검색 할 수 있는 API 입니다.
- 검색 필터링은 날짜, 증상, 중증도를 GET방식의 URL Query 형식으로 구분하며, 필터링을 걸지 않으면 전체 데이터가 조회됩니다.
- hospitals 및 reports 테이블의 위도, 경도 데이터를 소수점 4자리까지 밖에 저장할 수 없는 문제가 있어 해당 컬럼의 데이터 타입을 float에서 decimal로 변경하였습니다.