### PR TITLE
feat: add Harversine for Data filtering : 권용재

### DIFF
--- a/src/hospitals/controller/hospitals.controller.ts
+++ b/src/hospitals/controller/hospitals.controller.ts
@@ -1,6 +1,7 @@
 import { Controller, Get, Logger, Param, Query } from '@nestjs/common';
 import { HospitalsService } from '../service/hospitals.service';
 import { Hospitals } from '../hospitals.entity';
+
 @Controller('hospital')
 export class HospitalsController {
   private logger = new Logger('HospitalsController');
@@ -13,13 +14,10 @@ export class HospitalsController {
   }
 
   @Get('/local') // hospital/local?site=경기도
-  getLocalHospitals(
-    @Query('site') site: string
-  ): Promise<string[]> {
+  getLocalHospitals(@Query('site') site: string): Promise<string[]> {
     this.logger.verbose('Getting Local Hospitals');
     return this.hospitalsService.getLocalHospitals(site);
-  } 
-
+  }
 
   @Get('/nation')
   getNationHospitals(): Promise<JSON> {
@@ -29,10 +27,8 @@ export class HospitalsController {
 
   // 이쪽 API는 Query로 배열 파라미터를 넘겨줘야 합니다.
   @Get('nearby') // hospital/nearBy?emogList=A1100010&emogList=A1100011&emogList=A1400015
-  getNearbyHospitals(
-    @Query('emogList') emogList: string[]
-  ): Promise<string[]> {
-    this.logger.verbose('Getting Nearby Hospitals')
+  getNearbyHospitals(@Query('emogList') emogList: string[]): Promise<string[]> {
+    this.logger.verbose('Getting Nearby Hospitals');
     return this.hospitalsService.getNearByHospitals(emogList);
   }
 

--- a/src/hospitals/hospitals.repository.ts
+++ b/src/hospitals/hospitals.repository.ts
@@ -41,4 +41,20 @@ export class HospitalsRepository extends Repository<Hospitals> {
     //병원 위치(복수)
     return this.find();
   }
+
+  //harversine
+  async ConvertRadians(degree: number) {
+    return degree * (Math.PI / 180);
+  }
+  async arcLength(φ1: number, φ2: number, Δφ: number, Δλ: number) {
+    const arcLength =
+      Math.sin(Δφ / 2) * Math.sin(Δφ / 2) +
+      Math.cos(φ1) * Math.cos(φ2) * Math.sin(Δλ / 2) * Math.sin(Δλ / 2);
+    return arcLength;
+  }
+  async centralAngle(arcLength: number) {
+    const centralAngle =
+      2 * Math.atan2(Math.sqrt(arcLength), Math.sqrt(1 - arcLength));
+    return centralAngle;
+  }
 }

--- a/src/hospitals/service/hospitals.service.ts
+++ b/src/hospitals/service/hospitals.service.ts
@@ -5,6 +5,7 @@ import { Crawling } from 'src/commons/middlewares/crawling';
 import { KakaoMapService } from 'src/commons/utils/kakao-map.service';
 import { MedicalOpenAPI } from 'src/commons/middlewares/medicalOpenAPI';
 import { Hospitals } from '../hospitals.entity';
+import { number } from 'joi';
 
 @Injectable()
 export class HospitalsService {
@@ -49,23 +50,46 @@ export class HospitalsService {
   async getReccomendedHospitals(report_id: number) {
     //사용자 위치
     const userLocation = await this.reportRepository.userLocation(report_id);
-    // report_id가 없는 경우 예외처리가 필요합니다
+    // report_id가 없는 경우 예외처리
+    if (!userLocation) {
+      throw new NotFoundException('해당 아이디의 위치를 찾을 수 없습니다.');
+    }
     const startLat = userLocation[0];
     const startLng = userLocation[1];
 
-    // 여기서 바로 예외처리를 해주는게 맞는것 같습니다
+    // 여기서 바로 예외처리를 해주는게 맞음
     if (!startLat || !startLng) {
-      // null은 사용자가 없는 값이라고 명시적으로 표기하는 것이기 때문에 값이 실제로 없는 경우는 undefined이 납니다
-      throw new NotFoundException(
-        '환자의 현재 위치가 정상적으로 반영되지않았습니다.',
-      );
+      // null은 사용자가 없는 값이라고 명시적으로 표기하는 것이기 때문에 값이 실제로 없는 경우는 undefined 반환
+      throw new NotFoundException('현재 위치가 정상적으로 반영되지않았습니다.');
     }
-    //추천 병원 배열
-    const getRecommandHopitals = [];
 
-    //거리 계산 로직
+    //데이터 필터링 구간 시작//
+    let harversineHospitalsData = [];
+
     const HospitalsData = await this.hospitalsRepository.AllHospitals();
     for (const hospital of HospitalsData) {
+      const endLat = hospital.latitude;
+      const endLng = hospital.longitude;
+      const distance = this.harversine(startLat, startLng, endLat, endLng);
+      harversineHospitalsData.push({
+        hospital_id: hospital.hospital_id,
+        name: hospital.name,
+        phone: hospital.phone,
+        distance: distance,
+        available_beds: hospital.available_beds,
+        latitude: hospital.latitude,
+        longitude: hospital.longitude,
+      });
+    }
+    harversineHospitalsData.sort((a, b) => a.distance - b.distance);
+    harversineHospitalsData = harversineHospitalsData.slice(0, 20);
+    //데이터 필터링 구간 종료//
+
+    //최종 추천 병원 배열 세팅
+    const getRecommandHopitals = [];
+
+    // 카카오map API적용 최단시간 거리 계산
+    for (const hospital of harversineHospitalsData) {
       const endLat = hospital.latitude;
       const endLng = hospital.longitude;
 
@@ -77,7 +101,9 @@ export class HospitalsService {
       );
       getRecommandHopitals.push({
         duration: duration,
-        hospital: hospital.name,
+        distance: hospital.distance,
+        hospital_id: hospital.hospital_id,
+        name: hospital.name,
         phone: hospital.phone,
         available_beds: hospital.available_beds,
       });
@@ -87,6 +113,24 @@ export class HospitalsService {
 
     //최단거리 병원 duration 낮은 순(단위:sec)
     getRecommandHopitals.sort((a, b) => a.duration - b.duration);
-    return getRecommandHopitals.slice(0, 3);
+    return getRecommandHopitals.slice(0, 10);
+  }
+
+  //하버사인(데이터 필터링용)
+  async harversine(
+    startLat: number,
+    startLng: number,
+    endLat: number,
+    endLng: number,
+  ) {
+    const R = 6371e3;
+    const φ1 = await this.hospitalsRepository.ConvertRadians(startLat);
+    const φ2 = await this.hospitalsRepository.ConvertRadians(endLat); //경도만 라디안으로 각각 전환
+    const Δφ = await this.hospitalsRepository.ConvertRadians(endLat - startLat); //경도,위도 모두 차이값을 라디안으로 전환
+    const Δλ = await this.hospitalsRepository.ConvertRadians(endLng - startLng);
+    const arcLenght = await this.hospitalsRepository.arcLength(φ1, φ2, Δφ, Δλ);
+    const centralAngle = await this.hospitalsRepository.centralAngle(arcLenght);
+    const distance = R * centralAngle;
+    return distance;
   }
 }


### PR DESCRIPTION
[작업 사항]
1. 데이터 필터링 용으로 하버사인 공식 추가하여 카카오 API에 데이터 전송시 필터링 된 20개 데이터만 전달(카카오맵API 처리속도 개당 1.3sec=>183ms으로 성능 87% 향상(효율 7.2배))
=> 하지만 여전히 개당 속도이기 때문에 좀 더 속도 개선하면 좋을 것 같습니다.
3. 함수 인수 대입순서 lat1, lng1, lat2, lng2 순 적용

[기타]
레파지토리는 데이터베이스와 밀접하게 움직이는 구간인데
하버사인 공식에 있는 부분 계산식들은 사실 데이터 베이스의 데이터와는 관련이 없습니다..
 굳이 저렇게 repo에 세분화해서 나누는 게 맞을지..? 
아니면 공식을 통으로 service단에 넣는 게 맞을지 의견 나눠보면 좋을 것 같습니닷.