### PR TITLE
feat: 병원 조회 & 검색 페이지 1차 구현 완료

### DIFF
--- a/src/hospitals/hospitals.module.ts
+++ b/src/hospitals/hospitals.module.ts
@@ -19,7 +19,7 @@ import * as redisStore from 'cache-manager-ioredis';
       store: redisStore,
       host: 'localhost',
       port: 6379,
-      ttl: 6000,
+      ttl: 60,
     }),
   ],
   controllers: [HospitalsController],

--- a/src/hospitals/hospitals.module.ts
+++ b/src/hospitals/hospitals.module.ts
@@ -19,7 +19,7 @@ import * as redisStore from 'cache-manager-ioredis';
       store: redisStore,
       host: 'localhost',
       port: 6379,
-      ttl: 60,
+      ttl: 6000,
     }),
   ],
   controllers: [HospitalsController],

--- a/src/hospitals/service/hospitals.service.ts
+++ b/src/hospitals/service/hospitals.service.ts
@@ -136,7 +136,9 @@ export class HospitalsService {
             }
             const minutes = Math.floor(duration / 60);
             const seconds = Math.floor(duration % 60);
-            return {
+
+            const obj = {
+              ...report,
               duration,
               minutes: `${minutes}분`,
               seconds: `${seconds}초`,
@@ -146,11 +148,12 @@ export class HospitalsService {
               phone: hospital[1]['phone'],
               available_beds: hospital[1]['available_beds'],
               emogList: hospital[1]['emogList'],
-              ...report,
             };
+            return obj;
           });
 
           const recommendedHospitals = await Promise.all(promises);
+
           // 가중치 적용
           const weightsRecommendedHospitals = [];
           const weights = {
@@ -183,6 +186,7 @@ export class HospitalsService {
             0,
             10,
           );
+
           const emogList = [];
           for (const hospital of top10RecommendedHospitals) {
             emogList.push(hospital['emogList']);
@@ -190,7 +194,7 @@ export class HospitalsService {
           const datas = await this.crawling.getNearbyHospitals(emogList);
           const results: Array<string | object> = await Promise.all(
             top10RecommendedHospitals.map(async (hospital) => {
-              const result = { ...hospital };
+              const result = { ...hospital, report_id };
               for (const data of datas) {
                 if (data.slice(0, 8) === hospital.emogList) {
                   const beds_object = await this.parseHospitalData(data);
@@ -200,7 +204,6 @@ export class HospitalsService {
               return result;
             }),
           );
-
           results.unshift(datas[0]); // 크롤링 데이터 받아온 timeline
           // const end: any = new Date();
           // const t = end - start;
@@ -230,6 +233,7 @@ export class HospitalsService {
     );
     return getHospitals;
   }
+
   async calculateRating(
     hospital,
     weights: {

--- a/src/requests/controller/requests.controller.ts
+++ b/src/requests/controller/requests.controller.ts
@@ -44,7 +44,6 @@ export class RequestsController {
     this.logger.verbose('증상 보고서 검색 GET API');
     console.log(queries);
     const searchedData = await this.requestsService.getSearchRequests(queries);
-    console.log('searchedData: ', searchedData);
     return { searchedData };
   }
 

--- a/src/requests/service/requests.service.ts
+++ b/src/requests/service/requests.service.ts
@@ -352,10 +352,10 @@ export class RequestsService {
     console.log('job: ', job);
     console.log('3. waitFinish() 호출');
     // 대기열 큐에 job을 넣은 후, service 내에서 waitFinish() 함수를 호출한다
-    return this.waitFinish(eventName, 2); // 2 = second
+    return this.waitFinish(eventName, 2, hospital); // 2 = second
   }
 
-  async waitFinish(eventName: string, second: number) {
+  async waitFinish(eventName: string, second: number, hospital: object) {
     console.log('4. waitFinish() 진입');
     return new Promise((resolve, reject) => {
       console.log('5. Promise 진입');
@@ -379,7 +379,7 @@ export class RequestsService {
         console.log('7. listenFn 진입');
         clearTimeout(wait);
         this.eventEmitter.removeAllListeners(eventName);
-        success ? resolve({ message: '이송 신청 성공' }) : reject(exception);
+        success ? resolve({ hospital }) : reject(exception);
       };
       console.log('6. this.eventEmitter.addListener 세팅');
       // sendRequest()에서 전해준 이벤트가 성공이든 실패든,

--- a/views/recommendedHospitals.ejs
+++ b/views/recommendedHospitals.ejs
@@ -44,6 +44,42 @@
       rel="stylesheet"
     />
   </head>
+  <script>
+    function sendRequest(report_id, hospital_id) {
+      const url = `/request/${report_id}/${hospital_id}`;
+
+      fetch(url, {
+        method: 'POST',
+      })
+        .then((response) => {
+          return response.json();
+        })
+        .then((data) => {
+          console.log(data);
+          const notification = document.querySelector('.notification');
+          notification.style.display = 'block';
+          notification.textContent = `
+            해당 ${data.hospital.name}에 환자 이송 신청이 접수되었습니다.
+            환자의 증상 보고서가 병원측으로 전달되었습니다.
+          `
+        })
+        .catch((error) => {
+          console.error(error);
+        });
+    }
+
+    document.addEventListener('DOMContentLoaded', () => {
+      (document.querySelectorAll('.notification .delete') || []).forEach(
+        ($delete) => {
+          const $notification = $delete.parentNode;
+
+          $delete.addEventListener('click', () => {
+            $notification.parentNode.removeChild($notification);
+          });
+        },
+      );
+    });
+  </script>
   <body>
     <nav
       class="navbar is-info is-light"
@@ -106,6 +142,11 @@
               <div>환자의 혈압: <%=hospitals_data[1].blood_pressure%></div>
               <div>환자의 혈액형: <%=hospitals_data[1].blood_type%></div>
             </div>
+            <div class="notification is-danger is-light" style="display: none">
+              <button class="delete"></button>
+              해당 병원에 환자 이송 신청이 접수되었습니다.
+              환자의 증상 보고서가 병원측으로 전달되었습니다.
+            </div>
           </div>
         </div>
         <div class="box">
@@ -115,7 +156,10 @@
               <h3><%=hospitals_data[i].name %></h3>
               <div class="title-call-button">
                 <button class="button is-dark mr-3 mt-3">전화 걸기</button>
-                <button class="button is-danger is-dark mt-3">
+                <button
+                  class="button is-danger is-dark mt-3"
+                  onclick="sendRequest(`<%=hospitals_data[1].report_id%>`, `<%=hospitals_data[i].hospital_id%>`)"
+                >
                   환자 이송신청
                 </button>
               </div>

--- a/views/recommendedHospitals.ejs
+++ b/views/recommendedHospitals.ejs
@@ -34,6 +34,15 @@
       .button {
         font-family: 'Noto Sans KR', sans-serif;
       }
+
+      #fixedButton {
+        position: fixed;
+        bottom: 50px;
+        right: 45px;
+        width: 100px;
+        height: 100px;
+        border-radius: 50%;
+      }
     </style>
 
     <!-- google font -->
@@ -58,27 +67,49 @@
           console.log(data);
           const notification = document.querySelector('.notification');
           notification.style.display = 'block';
-          notification.textContent = `
-            해당 ${data.hospital.name}에 환자 이송 신청이 접수되었습니다.
-            환자의 증상 보고서가 병원측으로 전달되었습니다.
-          `
+          notification.innerHTML = `
+            <strong>${data.hospital.name}</strong>에 환자 이송 신청이 접수되었습니다. <br />
+            환자의 증상 보고서가 병원측으로 정상 전달되었습니다. <br />
+            <strong>병원 주소</strong>: ${data.hospital.address} <br />
+            <strong>병원 전화번호</strong>: ${data.hospital.phone} <br />
+          `;
+          const withdrawButton = document.querySelector('.withdraw');
+          withdrawButton.style.display = 'block';
         })
         .catch((error) => {
           console.error(error);
         });
     }
 
-    document.addEventListener('DOMContentLoaded', () => {
-      (document.querySelectorAll('.notification .delete') || []).forEach(
-        ($delete) => {
-          const $notification = $delete.parentNode;
+    function unsendRequest(report_id) {
+      const url = `/request/${report_id}`;
 
-          $delete.addEventListener('click', () => {
-            $notification.parentNode.removeChild($notification);
-          });
-        },
-      );
-    });
+      fetch(url, {
+        method: 'DELETE',
+      })
+        .then((response) => {
+          return response.json();
+        })
+        .then((data) => {
+          console.log(data);
+          const notification = document.querySelector('.notification');
+          notification.style.display = 'none';
+        })
+        .catch((error) => {
+          console.error(error);
+        });
+    }
+
+    function scrollToTop() {
+      window.scrollTo({
+        top: 0,
+        behavior: 'smooth',
+      });
+    }
+
+    function refreshBrowser() {
+      window.location.reload();
+    }
   </script>
   <body>
     <nav
@@ -132,6 +163,13 @@
     <div class="container is-max-widescreen">
       <div class="content hospitals_block" style="margin-top: 30px">
         <h2>현재 위치 기반 추천 병원 목록 (<%=hospitals_data[0]%> 기준)</h2>
+        <button
+          id="fixedButton"
+          class="button has-background-info-dark has-text-white-bis"
+          onclick="refreshBrowser()"
+        >
+          새로고침
+        </button>
         <div class="card">
           <div class="card-content">
             <div class="content">
@@ -142,10 +180,20 @@
               <div>환자의 혈압: <%=hospitals_data[1].blood_pressure%></div>
               <div>환자의 혈액형: <%=hospitals_data[1].blood_type%></div>
             </div>
-            <div class="notification is-danger is-light" style="display: none">
-              <button class="delete"></button>
-              해당 병원에 환자 이송 신청이 접수되었습니다.
-              환자의 증상 보고서가 병원측으로 전달되었습니다.
+            <% if (hospitals_data[1].is_sent) { %>
+            <button
+              class="withdraw button is-link is-light"
+              onclick="scrollToTop(); unsendRequest(`<%=hospitals_data[1].report_id%>`);"
+            >
+              병원 이송 신청 철회
+            </button>
+            <% } %>
+            <div
+              class="notification is-danger is-light mt-3"
+              style="display: none"
+            >
+              이미 병원에 이송 신청이 접수되었습니다. <br />
+              다른 병원에 신청을 하시려면 이전 신청을 철회해주세요.
             </div>
           </div>
         </div>
@@ -155,10 +203,15 @@
             <div class="hospital_title">
               <h3><%=hospitals_data[i].name %></h3>
               <div class="title-call-button">
-                <button class="button is-dark mr-3 mt-3">전화 걸기</button>
+                <button
+                  class="phone button is-dark mr-3 mt-3"
+                  title="<%=hospitals_data[i].phone %>"
+                >
+                  전화 걸기
+                </button>
                 <button
                   class="button is-danger is-dark mt-3"
-                  onclick="sendRequest(`<%=hospitals_data[1].report_id%>`, `<%=hospitals_data[i].hospital_id%>`)"
+                  onclick="scrollToTop(); sendRequest(`<%=hospitals_data[1].report_id%>`, `<%=hospitals_data[i].hospital_id%>`);"
                 >
                   환자 이송신청
                 </button>


### PR DESCRIPTION
* 병원조회 & 증상보고서 검색 페이지 구현 완료되었습니다
* 병원조회 이송신청을 한 후, 원래 페이지를 넘어가게 하려고 했는데 추천 병원들 조회한걸 계속 새로고침하면서 유저가 다른 병원을 선택할 수도 있어서 그냥 기존 페이지에 알람을 추가하였습니다.
* 유저가 이송신청 버튼을 누르면 페이지가 가장 상단으로 스크롤업되어 알람을 볼 수 있습니다.
* 알람부분을 새로고침한 이후에도 띄우고 싶었는데 시도했다가 모르겠어서 포기~ 했습니다 ㅎㅎ 대신 이송신청 버튼을 또 누르면 에러 메세지가 뜨게 했습니다
* navbar나 footer는 마지막 주차때 로고 결정하면서 같이 수정이 들어가면 될 것 같습니다.

Related: #98, #101