### PR TITLE
refactor: redis 캐싱 service layer -> cache interceptor

### DIFF
--- a/config/redis.config.ts
+++ b/config/redis.config.ts
@@ -4,6 +4,4 @@ export default registerAs('redis', () => ({
   host: process.env.REDIS_HOST,
   port: parseInt(process.env.REDIS_PORT),
   ttl: parseInt(process.env.REDIS_TTL),
-  username: process.env.REDIS_USERNAME,
-  password: process.env.REDIS_PASSWORD,
 }));

--- a/src/commons/interceptors/cache.interceptor.ts
+++ b/src/commons/interceptors/cache.interceptor.ts
@@ -11,37 +11,52 @@ import { Cache } from 'cache-manager';
 import { CACHE_MANAGER } from '@nestjs/cache-manager';
 
 @Injectable()
-export class CustomCacheInterceptor implements NestInterceptor {
+export class CacheInterceptor implements NestInterceptor {
+  protected allowedMethods = ['GET'];
   constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
 
   async intercept(
     context: ExecutionContext,
     next: CallHandler,
   ): Promise<Observable<any>> {
-    const request = context.switchToHttp().getRequest();
-    const cacheKey = this.generateCacheKey(request);
-    console.log('request:', request);
-    console.log('cacheKey:', cacheKey);
-    // 캐시 데이터 확인
-    const cachedData = await this.cacheManager.get(cacheKey);
-    if (cachedData) {
-      console.log('캐시된 데이터를 사용합니다.');
-      return of(cachedData);
-    }
+    // 추천 병원 조회 GET 요청인 경우에만 캐시 적용
+    if (this.isRequestGetRecommendedHospital(context)) {
+      const request = context.switchToHttp().getRequest();
+      const cacheKey = this.generateCacheKey(request);
+      console.log('cacheKey:', cacheKey);
+      // 캐시 데이터 확인
+      const cachedData = await this.cacheManager.get(cacheKey);
+      if (cachedData) {
+        console.log('캐시된 데이터를 사용합니다.');
+        return of(cachedData);
+      }
 
-    // 캐시된 데이터가 없는 경우 요청 처리
-    return next.handle().pipe(
-      tap((data) => {
-        // 데이터를 캐시에 저장
-        this.cacheManager.set(cacheKey, data);
-      }),
-    );
+      console.log('cacheManager:', this.cacheManager);
+      // 캐시된 데이터가 없는 경우 요청 처리
+      return next.handle().pipe(
+        tap((data) => {
+          // 데이터를 캐시에 저장
+          console.log('캐시에 데이터를 저장합니다.');
+          this.cacheManager.set(cacheKey, data, 60000);
+        }),
+      );
+    }
   }
 
   private generateCacheKey(request: Request): string {
     // 요청 URL과 쿼리 파라미터를 기반으로 고유한 캐시 키 생성
     const url = request.url;
-    const queryParams = JSON.stringify(request);
-    return `${url}:${queryParams}`;
+    console.log('url:', url);
+    const queryParams = JSON.stringify(url);
+    console.log('queryParams:', queryParams);
+    return `${queryParams}`;
+  }
+
+  private isRequestGetRecommendedHospital(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest();
+    const url = req.url;
+    return (
+      this.allowedMethods.includes(req.method) && url.startsWith('/hospital/')
+    );
   }
 }

--- a/src/commons/providers/bull-config.provider.ts
+++ b/src/commons/providers/bull-config.provider.ts
@@ -1,0 +1,21 @@
+import { Injectable } from '@nestjs/common';
+import {
+  BullModuleOptions,
+  SharedBullConfigurationFactory,
+} from '@nestjs/bull';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class BullConfigProvider implements SharedBullConfigurationFactory {
+  constructor(private configService: ConfigService) {}
+
+  createSharedConfiguration(): BullModuleOptions {
+    return {
+      redis: {
+        maxRetriesPerRequest: 20,
+        host: this.configService.get('REDIS_HOST'),
+        port: parseInt(this.configService.get('REDIS_PORT')),
+      },
+    };
+  }
+}

--- a/src/commons/providers/kakao-map.provider.ts
+++ b/src/commons/providers/kakao-map.provider.ts
@@ -9,19 +9,6 @@ export class KakaoMapService {
     @Inject(appConfig.KEY) private config: ConfigType<typeof appConfig>,
   ) {}
 
-  async convertCoordinatesToRegion(
-    latitude: number,
-    longitude: number,
-  ): Promise<string> {
-    const url = `https://dapi.kakao.com/v2/local/geo/coord2regioncode.json?x=${longitude}&y=${latitude}&input_coord=WGS84`;
-    const response = await axios.get(url, {
-      headers: {
-        Authorization: `KakaoAK ${this.config.kakaoApiKey}`,
-      },
-    });
-    return response.data.documents[0].region_1depth_name;
-  }
-
   async getDrivingResult(
     startLat: number,
     startLng: number,

--- a/src/commons/providers/redis-config.provider.ts
+++ b/src/commons/providers/redis-config.provider.ts
@@ -1,0 +1,19 @@
+import {
+  CacheModuleOptions,
+  CacheOptionsFactory,
+  Injectable,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+@Injectable()
+export class RedisConfigProvider implements CacheOptionsFactory {
+  constructor(private configService: ConfigService) {}
+
+  createCacheOptions(): CacheModuleOptions {
+    return {
+      host: this.configService.get('REDIS_HOST'),
+      port: parseInt(this.configService.get('REDIS_PORT')),
+      ttl: parseInt(this.configService.get('REDIS_TTL')),
+    };
+  }
+}

--- a/src/commons/providers/typeorm-config.provider.ts
+++ b/src/commons/providers/typeorm-config.provider.ts
@@ -24,7 +24,7 @@ export class MysqlConfigProvider implements TypeOrmOptionsFactory {
           ? this.config.test_database
           : this.config.database,
       entities: [Hospitals, Reports, Patients],
-      synchronize: this.config.mode === 'test', //true - 변경시마다 새롭게!
+      synchronize: this.config.mode === 'test',
       dropSchema: this.config.mode === 'test',
       logging: this.config.mode !== 'production',
     };

--- a/src/hospitals/controller/hospitals.controller.ts
+++ b/src/hospitals/controller/hospitals.controller.ts
@@ -1,18 +1,22 @@
-import { Controller, Get, Logger, Param, Query, Render } from '@nestjs/common';
+import {
+  Controller,
+  Get,
+  Logger,
+  Param,
+  Query,
+  Render,
+  UseInterceptors,
+} from '@nestjs/common';
 import { HospitalsService } from '../service/hospitals.service';
+import { CacheInterceptor } from '@nestjs/cache-manager';
 
 @Controller('hospital')
+@UseInterceptors(CacheInterceptor)
 export class HospitalsController {
   private logger = new Logger('HospitalsController');
   constructor(private hospitalsService: HospitalsService) {}
 
-  @Get('/local') // hospital/local?site=경기도
-  getLocalHospitals(@Query('site') site: string): Promise<string[]> {
-    this.logger.verbose('Getting Local Hospitals');
-    return this.hospitalsService.getLocalHospitals(site);
-  }
-
-  @Get('/:report_id') // hospital/1?latitude=37.1&longitude=127.1
+  @Get('/:report_id')
   @Render('recommendedHospitals')
   async getRecommendedHospitals(
     @Param('report_id') report_id: number,
@@ -24,10 +28,5 @@ export class HospitalsController {
       queries,
     );
     return { hospitals_data };
-  }
-
-  @Get('/crawl/naver')
-  getSymptomCrawl() {
-    return this.hospitalsService.getSymptomCrawl();
   }
 }

--- a/src/hospitals/service/hospitals.service.spec.ts
+++ b/src/hospitals/service/hospitals.service.spec.ts
@@ -1,7 +1,7 @@
 import { Test } from '@nestjs/testing';
 import { HospitalsService } from './hospitals.service';
 import { HospitalsRepository } from '../hospitals.repository';
-import { KakaoMapService } from '../../commons/providers/kakao-map.service';
+import { KakaoMapService } from '../../commons/providers/kakao-map.provider';
 import { ReportsRepository } from '../..//reports/reports.repository';
 import { Crawling } from '../../commons/middlewares/crawling';
 import { MedicalOpenAPI } from '../../commons/middlewares/medicalOpenAPI';

--- a/src/hospitals/service/hospitals.service.ts
+++ b/src/hospitals/service/hospitals.service.ts
@@ -8,13 +8,11 @@ import {
 import { HospitalsRepository } from '../hospitals.repository';
 import { ReportsRepository } from '../../reports/reports.repository';
 import { Crawling } from '../../commons/middlewares/crawling';
-import { KakaoMapService } from '../../commons/providers/kakao-map.service';
+import { KakaoMapService } from '../../commons/providers/kakao-map.provider';
 import { MedicalOpenAPI } from '../../commons/middlewares/medicalOpenAPI';
 import { Hospitals } from '../hospitals.entity';
 import { InjectEntityManager } from '@nestjs/typeorm'; //transaction사용을 위한 모듈 임포트
 import { EntityManager } from 'typeorm'; //transaction사용을 위한 모듈 임포트
-import { Cache } from 'cache-manager';
-import { CACHE_MANAGER } from '@nestjs/cache-manager';
 
 @Injectable()
 export class HospitalsService {
@@ -25,31 +23,10 @@ export class HospitalsService {
     private kakaoMapService: KakaoMapService,
     private openAPI: MedicalOpenAPI,
     @InjectEntityManager() private readonly entityManager: EntityManager, // 트랜젝션을 위해 DI
-    @Inject(CACHE_MANAGER) private cacheManager: Cache,
   ) {}
 
   async getHospitals(): Promise<Hospitals[]> {
     return this.hospitalsRepository.getHospitals();
-  }
-
-  // 지역 병상 데이터 조회 (string[], 메디서비스 기반)
-  async getLocalHospitals(site: string): Promise<string[]> {
-    /*
-      지역 옵션 선택
-      매개변수 site에 아래 지역 중 하나가 들어옵니다.
-      서울특별시 / 경기도 / 강원도 / 광주광역시 / 대구광역시
-      대전광역시 / 부산광역시 / 울산광역시 / 인천광역시 / 경상남도
-      경상북도 / 세종특별자치시 / 전라남도 / 전라북도 / 제주특별자치도
-      충청남도 / 충청북도
-    */
-    const results = await this.crawling.getLocalHospitaldata(site);
-    return results;
-  }
-
-  // 전국 병상 데이터 조회 (JSON, 공공데이터 API 기반)
-  async getNationHospitals(): Promise<JSON> {
-    const results = await this.openAPI.getMedicalData();
-    return results;
   }
 
   // 병원 추천 및 병상 조회 (종합상황판 기반)
@@ -57,23 +34,10 @@ export class HospitalsService {
     report_id: number,
     queries: object,
   ): Promise<any> {
-    // const start: any = new Date();
     const getHospitals = await this.entityManager.transaction(
       'READ COMMITTED',
       async () => {
         try {
-          // redis cache로 캐싱되어 있는 report_id인지 먼저 확인
-          const cachedResult: string = await this.cacheManager.get(
-            `cache:${report_id.toString()}:${queries['radius']}:${
-              queries['max_count']
-            }`,
-          );
-          // 캐싱되어 있으면 바로 return
-          if (cachedResult) {
-            console.log('캐싱된 데이터를 사용합니다.');
-            return JSON.parse(cachedResult);
-          }
-
           //사용자 위치
           const report = await this.reportsRepository.findReport(report_id);
           if (!report) {
@@ -211,19 +175,6 @@ export class HospitalsService {
           results.unshift(selectedHospital); // 사용자가 선택한 병원 정보 - index 2번 저장
           results.unshift(report); // 증상보고서 내용 - index 1번 저장
           results.unshift(datas[0]); // 크롤링 데이터 받아온 timeline - index 0번 저장
-          // const end: any = new Date();
-          // const t = end - start;
-          // console.log(`응답 시간 : ${t}ms`);
-
-          // redis cache에 저장
-          await this.cacheManager.set(
-            `cache:${report_id.toString()}:${queries['radius']}:${
-              queries['max_count']
-            }`,
-            JSON.stringify(results),
-            60 * 1000, // ms
-          );
-          console.log('redis cache에 저장');
 
           return results;
         } catch (error) {
@@ -260,10 +211,6 @@ export class HospitalsService {
       durationWeight * durationScore +
       available_bedsWeight * available_bedsScore;
     return rating;
-  }
-
-  async getSymptomCrawl() {
-    const data = await this.crawling.symptomCrawl();
   }
 
   async parseHospitalData(data: string) {

--- a/src/reports/reports.module.ts
+++ b/src/reports/reports.module.ts
@@ -4,7 +4,7 @@ import { ReportsService } from './service/reports.service';
 import { ReportsRepository } from './reports.repository';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { Reports } from './reports.entity';
-import { KakaoMapService } from '../commons/providers/kakao-map.service';
+import { KakaoMapService } from '../commons/providers/kakao-map.provider';
 import { PatientsRepository } from '../patients/patients.repository';
 
 @Module({

--- a/src/requests/requests.consumer.ts
+++ b/src/requests/requests.consumer.ts
@@ -9,9 +9,11 @@ export class RequestQueueConsumer {
 
   @Process('addRequestQueue')
   // 큐에 쌓인 job들을 FIFO (First In First Out)으로 가져와서 sendRequest() 함수에 전달한다
-  async handleAddRequestQueue(job: Job) {
+  async handleRequestQueue(job: Job) {
     console.log('2. handleAddRequestQueue 진입');
-    console.log(`3. ${job.data} 작업 수행 중`);
+    console.log(
+      `3. ${job.data.report_id} & ${job.data.hospital_id} 작업 수행 중`,
+    );
     return await this.requestsService.sendRequest(
       job.data.report_id,
       job.data.hospital_id,

--- a/src/requests/service/requests.service.ts
+++ b/src/requests/service/requests.service.ts
@@ -206,33 +206,18 @@ export class RequestsService {
 
   // 동시성 제어를 위한 메서드
   async addToRequestQueue(report_id: number, hospital_id: number) {
-    // queue에 넣기 전 report_id와 hospital_id validation
-    const hospital = await this.hospitalsRepository.findHospital(hospital_id);
-    if (!hospital) {
-      throw new NotFoundException('병원이 존재하지 않습니다.');
-    }
-
-    const report = await this.reportsRepository.findReport(report_id);
-    if (!report) {
-      throw new NotFoundException('증상 보고서가 존재하지 않습니다.');
-    }
-    console.log('1. requestQueue에 job 추가');
-    // requestQueue에 해당 event를 report_id와 hospital_id와 함께 add해준다
-    await this.requestQueue.add(
-      'addRequestQueue',
-      { report_id, hospital_id },
-      {
-        removeOnComplete: true,
-        removeOnFail: true,
-        priority: this.getPriority(report),
-      }, // 이후 대기열에서 Job을 처리할 때 처리했음에도 그대로 Redis에 쌓여있는걸 방지하기 위함
-    );
-  }
-
-  async sendRequest(report_id: number, hospital_id: number) {
     try {
-      console.log('4. sendRequest 진입');
+      // queue에 넣기 전 report_id와 hospital_id validation
       const hospital = await this.hospitalsRepository.findHospital(hospital_id);
+      if (!hospital) {
+        throw new NotFoundException('병원이 존재하지 않습니다.');
+      }
+
+      const report = await this.reportsRepository.findReport(report_id);
+      if (!report) {
+        throw new NotFoundException('증상 보고서가 존재하지 않습니다.');
+      }
+
       const available_beds = hospital.available_beds;
       if (available_beds === 0) {
         throw new HttpException(
@@ -241,7 +226,6 @@ export class RequestsService {
         );
       }
 
-      const report = await this.reportsRepository.findReport(report_id);
       if (report.is_sent) {
         throw new HttpException(
           '이미 전송된 증상 보고서입니다.',
@@ -249,14 +233,17 @@ export class RequestsService {
         );
       }
 
-      // 증상 보고서에 hospital_id 추가
-      await this.reportsRepository.addTargetHospital(report_id, hospital_id);
-
-      // 해당 병원의 available_beds를 1 감소
-      await this.hospitalsRepository.decreaseAvailableBeds(hospital_id);
-
-      // 해당 report의 is_sent를 true로 변경
-      await this.reportsRepository.updateReportBeingSent(report_id);
+      console.log('1. requestQueue에 job 추가');
+      // requestQueue에 해당 event를 report_id와 hospital_id와 함께 add해준다
+      await this.requestQueue.add(
+        'addRequestQueue',
+        { report_id, hospital_id },
+        {
+          removeOnComplete: true,
+          removeOnFail: true,
+          priority: this.getPriority(report),
+        }, // 이후 대기열에서 Job을 처리할 때 처리했음에도 그대로 Redis에 쌓여있는걸 방지하기 위함
+      );
 
       return await this.reportsRepository.getReportwithPatientInfo(report_id);
     } catch (error) {
@@ -268,6 +255,19 @@ export class RequestsService {
         error.status || HttpStatus.INTERNAL_SERVER_ERROR,
       );
     }
+  }
+
+  async sendRequest(report_id: number, hospital_id: number) {
+    console.log('4. sendRequest 진입');
+
+    // 증상 보고서에 hospital_id 추가
+    await this.reportsRepository.addTargetHospital(report_id, hospital_id);
+
+    // 해당 병원의 available_beds를 1 감소
+    await this.hospitalsRepository.decreaseAvailableBeds(hospital_id);
+
+    // 해당 report의 is_sent를 true로 변경
+    await this.reportsRepository.updateReportBeingSent(report_id);
   }
 
   async withdrawRequest(report_id: number) {

--- a/test/artillery/concurrency.test.script.yaml
+++ b/test/artillery/concurrency.test.script.yaml
@@ -2,7 +2,7 @@ config:
   target: "http://localhost:3000"
   phases:
     - arrivalRate: 60
-      duration: 10
+      duration: 1
   payload:
     path: "concurrency.test.script.csv"
     order: random


### PR DESCRIPTION
* 기존에 service layer에서 관리했던 caching을 commons/interceptors의 cache interceptor가 관리할 수 있게 설정하였습니다.
* Redis 연결이 필요한 두 폴더 requests & hospitals module에서 useClass를 사용하여 redis 연결을 할 수 있게 리팩토링하였습니다.