### PR TITLE
fix: max_count & radius 반영시 새로고침 버그 수정

### DIFF
--- a/src/commons/interceptors/cache.interceptor.ts
+++ b/src/commons/interceptors/cache.interceptor.ts
@@ -46,9 +46,7 @@ export class CacheInterceptor implements NestInterceptor {
   private generateCacheKey(request: Request): string {
     // 요청 URL과 쿼리 파라미터를 기반으로 고유한 캐시 키 생성
     const url = request.url;
-    console.log('url:', url);
     const queryParams = JSON.stringify(url);
-    console.log('queryParams:', queryParams);
     return `${queryParams}`;
   }
 

--- a/src/commons/providers/redis-config.provider.ts
+++ b/src/commons/providers/redis-config.provider.ts
@@ -4,6 +4,7 @@ import {
   Injectable,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import * as redisCacheStore from 'cache-manager-ioredis';
 
 @Injectable()
 export class RedisConfigProvider implements CacheOptionsFactory {
@@ -11,6 +12,7 @@ export class RedisConfigProvider implements CacheOptionsFactory {
 
   createCacheOptions(): CacheModuleOptions {
     return {
+      store: redisCacheStore,
       host: this.configService.get('REDIS_HOST'),
       port: parseInt(this.configService.get('REDIS_PORT')),
       ttl: parseInt(this.configService.get('REDIS_TTL')),

--- a/src/hospitals/hospitals.module.ts
+++ b/src/hospitals/hospitals.module.ts
@@ -9,8 +9,6 @@ import { Crawling } from '../commons/middlewares/crawling';
 import { KakaoMapService } from '../commons/providers/kakao-map.provider';
 import { MedicalOpenAPI } from '../commons/middlewares/medicalOpenAPI';
 import { CacheModule } from '@nestjs/cache-manager';
-import { APP_INTERCEPTOR } from '@nestjs/core';
-import { CacheInterceptor } from '../commons/interceptors/cache.interceptor';
 import { RedisConfigProvider } from 'src/commons/providers/redis-config.provider';
 
 @Module({
@@ -28,10 +26,6 @@ import { RedisConfigProvider } from 'src/commons/providers/redis-config.provider
     Crawling,
     KakaoMapService,
     MedicalOpenAPI,
-    // {
-    //   provide: APP_INTERCEPTOR,
-    //   useClass: CacheInterceptor,
-    // },
   ],
   exports: [HospitalsService, HospitalsRepository],
 })

--- a/src/hospitals/hospitals.module.ts
+++ b/src/hospitals/hospitals.module.ts
@@ -28,10 +28,10 @@ import { RedisConfigProvider } from 'src/commons/providers/redis-config.provider
     Crawling,
     KakaoMapService,
     MedicalOpenAPI,
-    {
-      provide: APP_INTERCEPTOR,
-      useClass: CacheInterceptor,
-    },
+    // {
+    //   provide: APP_INTERCEPTOR,
+    //   useClass: CacheInterceptor,
+    // },
   ],
   exports: [HospitalsService, HospitalsRepository],
 })

--- a/views/createReport.ejs
+++ b/views/createReport.ejs
@@ -77,16 +77,9 @@
               .then((position) => {
                 const latitude = position.coords.latitude;
                 const longitude = position.coords.longitude;
-                const radius = null;
-                const maxCount = null;
 
                 let recommendedHospitals = `/hospital/${reportId}?latitude=${latitude}&longitude=${longitude}`;
-                if (radius) {
-                  recommendedHospitals += `&radius=${radius}`;
-                }
-                if (maxCount) {
-                  recommendedHospitals += `&max_count=${maxCount}`;
-                }
+
                 return fetch(recommendedHospitals)
                   .then((response) => response.text())
                   .then((text) => {
@@ -108,14 +101,6 @@
             console.error('Error:', error);
             alert('데이터 저장 중에 오류가 발생했습니다.');
           });
-      }
-
-      function scrollToTop() {
-        event.preventDefault();
-        window.scrollTo({
-          top: 0,
-          behavior: 'smooth',
-        });
       }
 
       function refreshBrowser() {
@@ -310,7 +295,7 @@
                     <button
                       type="submit"
                       class="button is-link"
-                      onclick="scrollToTop(); sendReport();"
+                      onclick="sendReport();"
                     >
                       제출
                     </button>

--- a/views/recommendedHospitals.ejs
+++ b/views/recommendedHospitals.ejs
@@ -126,6 +126,8 @@
     }
 
     function refreshBrowser() {
+      var currentUrl = window.location.href;
+      console.log(currentUrl);
       window.location.reload();
     }
 


### PR DESCRIPTION
* 병원조회 캐싱 redis로 연결되지 않고 Nest.js 서버 메모리에 캐싱되는 문제를 해결해서 현재는 네이버 클라우드 redis에서 병원조회 캐싱이 잘 적용되는 걸 확인했습니다.
* max_count & radius 반영 후 새로고침시 다시 반영 전으로 돌아가는 버그 수정 완료하였습니다.
* 기존 pr에서 cache interceptor를 전역으로 설정하여 api 호출이 정상적으로 이루어지지 않았었는데 이부분을 수정하였습니다.