### PR TITLE
fix: 이송신청, 철회시 관련 cached data 삭제

### DIFF
--- a/src/commons/interceptors/cache.interceptor.ts
+++ b/src/commons/interceptors/cache.interceptor.ts
@@ -12,7 +12,7 @@ import { CACHE_MANAGER } from '@nestjs/cache-manager';
 
 @Injectable()
 export class CacheInterceptor implements NestInterceptor {
-  protected allowedMethods = ['GET'];
+  protected cacheMethods = ['GET'];
   constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
 
   async intercept(
@@ -20,7 +20,7 @@ export class CacheInterceptor implements NestInterceptor {
     next: CallHandler,
   ): Promise<Observable<any>> {
     // 추천 병원 조회 GET 요청인 경우에만 캐시 적용
-    if (this.isRequestGetRecommendedHospital(context)) {
+    if (this.isRequestGet(context)) {
       const request = context.switchToHttp().getRequest();
       const cacheKey = this.generateCacheKey(request);
       console.log('cacheKey:', cacheKey);
@@ -36,7 +36,7 @@ export class CacheInterceptor implements NestInterceptor {
         tap((data) => {
           // 데이터를 캐시에 저장
           console.log('캐시에 데이터를 저장합니다.');
-          this.cacheManager.set(cacheKey, data, 60000);
+          this.cacheManager.set(cacheKey, data);
         }),
       );
     }
@@ -50,11 +50,8 @@ export class CacheInterceptor implements NestInterceptor {
     return `${reportId}:${radius}:${maxCount}`;
   }
 
-  private isRequestGetRecommendedHospital(context: ExecutionContext): boolean {
+  private isRequestGet(context: ExecutionContext): boolean {
     const req = context.switchToHttp().getRequest();
-    const url = req.url;
-    return (
-      this.allowedMethods.includes(req.method) && url.startsWith('/hospital/')
-    );
+    return this.cacheMethods.includes(req.method);
   }
 }

--- a/src/commons/interceptors/cache.interceptor.ts
+++ b/src/commons/interceptors/cache.interceptor.ts
@@ -31,7 +31,6 @@ export class CacheInterceptor implements NestInterceptor {
         return of(cachedData);
       }
 
-      console.log('cacheManager:', this.cacheManager);
       // 캐시된 데이터가 없는 경우 요청 처리
       return next.handle().pipe(
         tap((data) => {
@@ -43,11 +42,12 @@ export class CacheInterceptor implements NestInterceptor {
     }
   }
 
-  private generateCacheKey(request: Request): string {
+  private generateCacheKey(request): string {
     // 요청 URL과 쿼리 파라미터를 기반으로 고유한 캐시 키 생성
-    const url = request.url;
-    const queryParams = JSON.stringify(url);
-    return `${queryParams}`;
+    const reportId = request.params.report_id;
+    const radius = request.query.radius;
+    const maxCount = request.query.max_count;
+    return `${reportId}:${radius}:${maxCount}`;
   }
 
   private isRequestGetRecommendedHospital(context: ExecutionContext): boolean {

--- a/src/commons/interceptors/clear-cache.interceptor.ts
+++ b/src/commons/interceptors/clear-cache.interceptor.ts
@@ -1,0 +1,47 @@
+import {
+  Injectable,
+  NestInterceptor,
+  ExecutionContext,
+  CallHandler,
+  Inject,
+} from '@nestjs/common';
+import { Observable } from 'rxjs';
+import { tap } from 'rxjs/operators';
+import { Cache } from 'cache-manager';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+
+@Injectable()
+export class ClearCacheInterceptor implements NestInterceptor {
+  protected clearCacheMethods = ['POST', 'DELETE'];
+  constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
+
+  async intercept(
+    context: ExecutionContext,
+    next: CallHandler,
+  ): Promise<Observable<any>> {
+    // 이송 신청 & 철회 요청인 경우 캐시 삭제
+    if (this.isRequestPostOrDelete(context)) {
+      const request = context.switchToHttp().getRequest();
+      console.log('request.params.report_id:', request.params.report_id);
+      await this.clearCacheKeysStartingWith(request.params.report_id);
+    }
+    return next.handle();
+  }
+
+  private async clearCacheKeysStartingWith(reportId: string): Promise<void> {
+    const cacheKeys = await this.getCacheKeysStartingWith(reportId);
+    console.log('before Clear - cacheKeys:', cacheKeys);
+    await Promise.all(cacheKeys.map((key) => this.cacheManager.del(key)));
+  }
+
+  private async getCacheKeysStartingWith(prefix: string): Promise<string[]> {
+    const cacheKeys = await this.cacheManager.store.keys('*');
+    console.log('cacheKeys:', cacheKeys);
+    return cacheKeys.filter((key) => key.startsWith(`${prefix}:`));
+  }
+
+  private isRequestPostOrDelete(context: ExecutionContext): boolean {
+    const req = context.switchToHttp().getRequest();
+    return this.clearCacheMethods.includes(req.method);
+  }
+}

--- a/src/hospitals/controller/hospitals.controller.ts
+++ b/src/hospitals/controller/hospitals.controller.ts
@@ -8,7 +8,7 @@ import {
   UseInterceptors,
 } from '@nestjs/common';
 import { HospitalsService } from '../service/hospitals.service';
-import { CacheInterceptor } from '@nestjs/cache-manager';
+import { CacheInterceptor } from '../../commons/interceptors/cache.interceptor';
 
 @Controller('hospital')
 @UseInterceptors(CacheInterceptor)
@@ -27,7 +27,6 @@ export class HospitalsController {
       report_id,
       queries,
     );
-    console.log(hospitals_data);
     return { hospitals_data };
   }
 

--- a/src/hospitals/hospitals.module.ts
+++ b/src/hospitals/hospitals.module.ts
@@ -8,7 +8,7 @@ import { Hospitals } from './hospitals.entity';
 import { Crawling } from '../commons/middlewares/crawling';
 import { KakaoMapService } from '../commons/providers/kakao-map.provider';
 import { MedicalOpenAPI } from '../commons/middlewares/medicalOpenAPI';
-import { CacheModule } from '@nestjs/cache-manager';
+import { CacheInterceptor, CacheModule } from '@nestjs/cache-manager';
 import { RedisConfigProvider } from 'src/commons/providers/redis-config.provider';
 
 @Module({
@@ -26,6 +26,7 @@ import { RedisConfigProvider } from 'src/commons/providers/redis-config.provider
     Crawling,
     KakaoMapService,
     MedicalOpenAPI,
+    CacheInterceptor,
   ],
   exports: [HospitalsService, HospitalsRepository],
 })

--- a/src/hospitals/hospitals.module.ts
+++ b/src/hospitals/hospitals.module.ts
@@ -8,7 +8,7 @@ import { Hospitals } from './hospitals.entity';
 import { Crawling } from '../commons/middlewares/crawling';
 import { KakaoMapService } from '../commons/providers/kakao-map.provider';
 import { MedicalOpenAPI } from '../commons/middlewares/medicalOpenAPI';
-import { CacheInterceptor, CacheModule } from '@nestjs/cache-manager';
+import { CacheModule } from '@nestjs/cache-manager';
 import { RedisConfigProvider } from 'src/commons/providers/redis-config.provider';
 
 @Module({
@@ -26,7 +26,6 @@ import { RedisConfigProvider } from 'src/commons/providers/redis-config.provider
     Crawling,
     KakaoMapService,
     MedicalOpenAPI,
-    CacheInterceptor,
   ],
   exports: [HospitalsService, HospitalsRepository],
 })

--- a/src/hospitals/service/hospitals.service.ts
+++ b/src/hospitals/service/hospitals.service.ts
@@ -226,7 +226,7 @@ export class HospitalsService {
     };
   }
 
-  async getNearbyHospitals(queries: object): Promise<Object> {
+  async getNearbyHospitals(queries: object): Promise<object> {
     // parseFloat = 문자열을 부동 소수점 숫자로 변환
     const startLat = parseFloat(queries['latitude']);
     const startLng = parseFloat(queries['longitude']);

--- a/src/requests/controller/requests.controller.ts
+++ b/src/requests/controller/requests.controller.ts
@@ -6,12 +6,15 @@ import {
   Param,
   Query,
   Render,
+  UseInterceptors,
 } from '@nestjs/common';
 import { RequestsService } from '../service/requests.service';
 import { Logger } from '@nestjs/common';
 import { Reports } from 'src/reports/reports.entity';
+import { ClearCacheInterceptor } from 'src/commons/interceptors/clear-cache.interceptor';
 
 @Controller('request')
+@UseInterceptors(ClearCacheInterceptor)
 export class RequestsController {
   private logger = new Logger('RequestsController');
   constructor(private requestsService: RequestsService) {}

--- a/src/requests/requests.module.ts
+++ b/src/requests/requests.module.ts
@@ -11,6 +11,8 @@ import { ExpressAdapter } from '@bull-board/express';
 import { BullAdapter } from '@bull-board/api/bullAdapter';
 import { Queue } from 'bull';
 import { BullConfigProvider } from '../commons/providers/bull-config.provider';
+import { RedisConfigProvider } from '../commons/providers/redis-config.provider';
+import { CacheModule } from '@nestjs/cache-manager';
 
 @Module({
   imports: [
@@ -22,6 +24,9 @@ import { BullConfigProvider } from '../commons/providers/bull-config.provider';
     BullModule.registerQueue({
       configKey: 'bullqueue-config',
       name: 'requestQueue',
+    }),
+    CacheModule.registerAsync({
+      useClass: RedisConfigProvider,
     }),
   ],
   controllers: [RequestsController],

--- a/test/artillery/concurrency.test.script.yaml
+++ b/test/artillery/concurrency.test.script.yaml
@@ -1,7 +1,7 @@
 config:
   target: "http://localhost:3000"
   phases:
-    - arrivalRate: 60
+    - arrivalRate: 30
       duration: 1
   payload:
     path: "concurrency.test.script.csv"

--- a/views/createReport.ejs
+++ b/views/createReport.ejs
@@ -78,7 +78,7 @@
                 const latitude = position.coords.latitude;
                 const longitude = position.coords.longitude;
 
-                let recommendedHospitals = `/hospital/${reportId}?latitude=${latitude}&longitude=${longitude}`;
+                let recommendedHospitals = `/hospital/${reportId}?latitude=${latitude}&longitude=${longitude}&radius=&max_count=`;
 
                 return fetch(recommendedHospitals)
                   .then((response) => response.text())

--- a/views/recommendedHospitals.ejs
+++ b/views/recommendedHospitals.ejs
@@ -125,23 +125,49 @@
       });
     }
 
+    function getCurrentPosition() {
+      return new Promise((resolve, reject) => {
+        navigator.geolocation.getCurrentPosition(resolve, reject);
+      });
+    }
+
     function refreshBrowser() {
-      var currentUrl = window.location.href;
-      console.log(currentUrl);
-      window.location.reload();
+      // 현재 url에서 report_id 가져오기
+      const currentUrl = window.location.href;
+      const reportId = currentUrl.split('/')[4].split('?')[0];
+      // URL에 max_count & radius 쿼리 스트링 추가하기
+      const params = new URLSearchParams(window.location.search);
+      const radius = params.get('radius');
+      const max_count = params.get('max_count');
+
+      // 새로운 위치 좌표 반영
+      getCurrentPosition()
+        .then((position) => {
+          const latitude = position.coords.latitude;
+          const longitude = position.coords.longitude;
+
+          const recommendedHospitalsUrl = `/hospital/${reportId}?latitude=${latitude}&longitude=${longitude}&radius=${radius}&max_count=${max_count}`;
+          
+          // 페이지 다시 로드
+          window.location.href = recommendedHospitalsUrl;
+        })
+        .catch((error) => {
+          console.error(error);
+          alert('위치 정보를 가져오는데 실패했습니다.');
+        });
     }
 
     function addQueryString(position) {
       // 현재 URL 가져오기
-      var currentUrl = window.location.href;
+      const currentUrl = window.location.href;
 
       // URL에 쿼리 스트링 추가하기
-      var params = new URLSearchParams(window.location.search);
+      const params = new URLSearchParams(window.location.search);
       const radius = document.querySelector('#radius').value;
       const max_count = document.querySelector('#max_count').value;
       params.set('radius', radius);
       params.set('max_count', max_count);
-      var updatedUrl = currentUrl.split('?')[0] + '?' + params.toString();
+      const updatedUrl = currentUrl.split('?')[0] + '?' + params.toString();
 
       // 페이지 다시 로드
       window.location.href = updatedUrl;
@@ -156,11 +182,7 @@
     >
       <div class="navbar-brand">
         <a class="navbar-item" href="/">
-          <img
-            src="./image/onlytext-cutout.png"
-            width="120"
-            height="auto"
-          />
+          <img src="./image/onlytext-cutout.png" width="120" height="auto" />
         </a>
         <a
           role="button"
@@ -181,7 +203,9 @@
           <div class="navbar-item has-dropdown is-hoverable">
             <a class="navbar-link"> More </a>
             <div class="navbar-dropdown">
-              <a class="navbar-item" href="/hospital/inquery/nearbyHospitals"> 가까운 병원 조회 </a>
+              <a class="navbar-item" href="/hospital/inquery/nearbyHospitals">
+                가까운 병원 조회
+              </a>
               <a class="navbar-item"> 증상보고서 수정 </a>
               <a class="navbar-item"> 환자 정보 입력 및 수정 </a>
               <hr class="navbar-divider" />

--- a/views/recommendedHospitals.ejs
+++ b/views/recommendedHospitals.ejs
@@ -89,9 +89,13 @@
         })
         .then((data) => {
           console.log(data);
-          window.location.reload();
-          const errorMessage = document.querySelector('#errorMessage');
-          errorMessage.style.display = 'block';
+          if (data.report_id === report_id) {
+            window.location.reload();
+          }
+          if (data.statusCode === 400) {
+            const errorMessage = document.querySelector('#errorMessage');
+            errorMessage.style.display = 'block';
+          }
         })
         .catch((error) => {
           console.error(error);
@@ -110,8 +114,6 @@
         .then((data) => {
           console.log(data);
           window.location.reload();
-          const errorMessage = document.querySelector('#errorMessage');
-          errorMessage.style.display = 'none';
         })
         .catch((error) => {
           console.error(error);
@@ -147,7 +149,7 @@
           const longitude = position.coords.longitude;
 
           const recommendedHospitalsUrl = `/hospital/${reportId}?latitude=${latitude}&longitude=${longitude}&radius=${radius}&max_count=${max_count}`;
-          
+
           // 페이지 다시 로드
           window.location.href = recommendedHospitalsUrl;
         })


### PR DESCRIPTION
* 전반적인 cache redis 사용 부분을 수정하였습니다.
* FE에서 이송신청/철회하는 경우 캐싱된 데이터를 삭제하지 않으면 어떤 병원으로 이송하는지에 대한 알림창이 뜨는 것과 철회 버튼 생성에 문제가 있어서 이송 신청과 철회시 redis에 들어있던 데이터를 삭제하는 코드를 commons/interceptors/clear-cache.interceptor.ts에 구현하였습니다.
* 또한, 병원조회시 caching되는 데이터의 key값을 `report_id:radius:max_count`로 설정해주었습니다.
* 관련 자세한 내용은 노션 트러블슈팅 캐시 처리 & 무효화 페이지 확인해주시면 됩니다.