### PR TITLE
fix: FE 증상보고서 상세조회 & 검색 결과 버그 수정

### DIFF
--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -18,8 +18,7 @@ export class AppController {
   @Get('/search')
   @Render('reportSearchEngine')
   async search() {
-    const count = await this.reportService.getDataCount();
-    return { count: count };
+    return { name: 'name' };
   }
 
   @Get('/symptom-report')

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -22,7 +22,7 @@ export class AppController {
     return { count: count };
   }
 
-  @Get('/report')
+  @Get('/symptom-report')
   @Render('createReport')
   report() {
     return { name: 'name' };

--- a/src/reports/reports.repository.ts
+++ b/src/reports/reports.repository.ts
@@ -22,7 +22,6 @@ export class ReportsRepository extends Repository<Reports> {
   async getReportwithPatientInfo(report_id: number): Promise<Reports> {
     const report = await this.query(
       `
-          EXPLAIN
           SELECT
             r.report_id,
             r.symptom_level,
@@ -47,7 +46,6 @@ export class ReportsRepository extends Repository<Reports> {
   async getReportwithHospitalInfo(report_id: number): Promise<any> {
     const result = await this.query(
       `
-          EXPLAIN 
           SELECT
             r.report_id,
             r.symptom_level,
@@ -72,7 +70,6 @@ export class ReportsRepository extends Repository<Reports> {
   async getReportwithPatientAndHospitalInfo(report_id: number): Promise<any> {
     const result = await this.query(
       `
-          EXPLAIN 
           SELECT
             r.report_id,
             p.name AS patient_name,

--- a/views/createReport.ejs
+++ b/views/createReport.ejs
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- Favicon -->
-    <link rel="icon" href="./image/codeblue-favicon.png" />
-    <link rel="apple-touch-icon" href="./image/codeblue-favicon.png" />
+    <link rel="icon" href="../../image/codeblue-favicon.png" />
+    <link rel="apple-touch-icon" href="../../image/codeblue-favicon.png" />
 
     <title>CodeBLUE - 증상 보고서 입력 페이지</title>
 
@@ -15,7 +15,7 @@
     <meta property="og:url" content="https://codeblue.site" />
     <meta property="og:title" content="CodeBLUE" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="./image/codeblue.png" />
+    <meta property="og:image" content="../../image/codeblue.png" />
     <meta property="og:description" content="CodeBLUE - 증상 보고서 입력 페이지"/>
 
     <link
@@ -138,7 +138,7 @@
       </div>
       <div id="navbarBasicExample" class="navbar-menu">
         <div class="navbar-start">
-          <a class="navbar-item" href="/report"> 증상보고서 입력 </a>
+          <a class="navbar-item" href="/symptom-report"> 증상보고서 입력 </a>
           <a class="navbar-item" href="/search"> 증상보고서 검색 </a>
           <div class="navbar-item has-dropdown is-hoverable">
             <a class="navbar-link"> More </a>

--- a/views/index.ejs
+++ b/views/index.ejs
@@ -71,7 +71,7 @@
       </p>
       <div class="selections">
         <a
-          href="/report"
+          href="/symptom-report"
           class="button is-info is-light is-size-5 has-text-weight-bold"
           >증상 보고서 입력 및 추천 응급실 조회</a
         >

--- a/views/nearbyHospitals.ejs
+++ b/views/nearbyHospitals.ejs
@@ -144,7 +144,7 @@
       </div>
       <div id="navbarBasicExample" class="navbar-menu">
         <div class="navbar-start">
-          <a class="navbar-item" href="/report"> 증상보고서 입력 </a>
+          <a class="navbar-item" href="/symptom-report"> 증상보고서 입력 </a>
           <a class="navbar-item" href="/search"> 증상보고서 검색 </a>
           <div class="navbar-item has-dropdown is-hoverable">
             <a class="navbar-link"> More </a>

--- a/views/recommendedHospitals.ejs
+++ b/views/recommendedHospitals.ejs
@@ -204,7 +204,7 @@
       </div>
       <div id="navbarBasicExample" class="navbar-menu">
         <div class="navbar-start">
-          <a class="navbar-item" href="/report"> 증상보고서 입력 </a>
+          <a class="navbar-item" href="/symptom-report"> 증상보고서 입력 </a>
           <a class="navbar-item" href="/search"> 증상보고서 검색 </a>
           <div class="navbar-item has-dropdown is-hoverable">
             <a class="navbar-link"> More </a>

--- a/views/reportDetail.ejs
+++ b/views/reportDetail.ejs
@@ -16,7 +16,10 @@
     <meta property="og:title" content="CodeBLUE" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="../../image/codeblue.png" />
-    <meta property="og:description" content="CodeBLUE - 증상 보고서 상세 페이지" />
+    <meta
+      property="og:description"
+      content="CodeBLUE - 증상 보고서 상세 페이지"
+    />
 
     <link
       rel="stylesheet"
@@ -48,6 +51,19 @@
         width: 100px;
         height: 100px;
         border-radius: 50%;
+      }
+
+      table {
+        width: 100%;
+        table-layout: fixed;
+      }
+
+      td {
+        padding: 10px;
+      }
+
+      .container {
+        margin: 50px 185px 50px 185px;
       }
     </style>
   </head>
@@ -90,7 +106,9 @@
           <div class="navbar-item has-dropdown is-hoverable">
             <a class="navbar-link"> More </a>
             <div class="navbar-dropdown">
-              <a class="navbar-item" href="/hospital/inquery/nearbyHospitals"> 가까운 병원 조회 </a>
+              <a class="navbar-item" href="/hospital/inquery/nearbyHospitals">
+                가까운 병원 조회
+              </a>
               <a class="navbar-item"> 증상보고서 수정 </a>
               <a class="navbar-item"> 환자 정보 입력 및 수정 </a>
               <hr class="navbar-divider" />
@@ -111,34 +129,51 @@
           돌아가기
         </button>
         <div class="box">
+          <% if (reportDetails.patient_rrn) { %>
           <div class="box has-background-light">
-            <% if (reportDetails.patient_rrn) { %>
             <h3>환자 정보</h3>
-            <div style="margin-left: 20px">
-              <p><strong>이름 </strong><%=reportDetails.patient_name%></p>
-              <p><strong>성별 </strong><%=reportDetails.gender%></p>
-              <p>
-                <strong>주민등록번호 </strong><%=reportDetails.patient_rrn%>
-              </p>
-            </div>
-            <% } %>
+            <table>
+              <tbody>
+                <tr>
+                  <td><strong>이름</strong></td>
+                  <td><%=reportDetails.patient_name%></td>
+                </tr>
+                <tr>
+                  <td><strong>성별</strong></td>
+                  <% let gender; %> <% if(reportDetails.gender === 'M') { gender
+                  = '남성' } else { gender = '여성'} %>
+                  <td><%=gender %></td>
+                </tr>
+                <tr>
+                  <td><strong>주민등록번호</strong></td>
+                  <% let hidden_rnn =
+                  reportDetails.patient_rrn.replace(/(\d{6})$/, '******');%>
+                  <td><%=hidden_rnn%></td>
+                </tr>
+              </tbody>
+            </table>
           </div>
+          <% } %>
           <div class="box has-background-light">
-            <% if (reportDetails.patient_rrn) { %>
             <h3>증상 상세 정보</h3>
-            <div style="margin-left: 20px">
-              <p>
-                <strong>중증도 등급 </strong><%=reportDetails.symptom_level%>
-              </p>
-              <p><strong>연령대 </strong><%=reportDetails.age_range%></p>
-              <p><strong>혈압 </strong><%=reportDetails.blood_pressure%></p>
-              <p><strong>세부 증상 </strong></p>
-            </div>
-            <div style="margin-left: 20px; margin-top: 5px">
-              <blockquote style="background-color: rgb(182, 204, 224)">
-                <%=reportDetails.symptoms%>
-              </blockquote>
-              <ul>
+            <table>
+              <tbody>
+                <tr>
+                  <td><strong>중증도 등급</strong></td>
+                  <td class="has-text-danger"><%=reportDetails.symptom_level%></td>
+                </tr>
+                <tr>
+                  <td><strong>연령대</strong></td>
+                  <td><%=reportDetails.age_range%></td>
+                </tr>
+                <tr>
+                  <td><strong>혈압</strong></td>
+                  <td><%=reportDetails.blood_pressure%></td>
+                </tr>
+                <tr>
+                  <td><strong>세부 증상</strong></td>
+                  <td class="has-text-link"><%=reportDetails.symptoms%></td>
+                </tr>
                 <% const originalDate = reportDetails.createdAt; %> <% const
                 year = originalDate.getFullYear(); %> <% const month =
                 originalDate.getMonth() + 1; %> <% const date =
@@ -151,21 +186,24 @@
                 updateDate.getDate(); %> <% const updatedHours =
                 updateDate.getHours(); %> <% const updatedMinutes =
                 updateDate.getMinutes(); %>
-              </ul>
-            </div>
-            <div style="margin-left: 20px">
-              <p>
-                <strong>작성 날짜 </strong> <%= `${year}년 ${month}월 ${date}일
-                ${hours}시 ${minutes}분` %>
-              </p>
-              <p>
-                <strong>최종 수정 날짜 </strong><%= `${updatedYear}년
-                ${updatedMonth}월 ${updatedDate}일 ${updatedHours}시
-                ${updatedMinutes}분` %>
-              </p>
-            </div>
-            <% } %>
+                <tr>
+                  <td><strong>작성 날짜</strong></td>
+                  <td>
+                    <%= `${year}년 ${month}월 ${date}일 ${hours}시 ${minutes}분`
+                    %>
+                  </td>
+                </tr>
+                <tr>
+                  <td><strong>최종 수정 날짜</strong></td>
+                  <td>
+                    <%= `${updatedYear}년 ${updatedMonth}월 ${updatedDate}일
+                    ${updatedHours}시 ${updatedMinutes}분` %>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
           </div>
+
           <div class="box has-background-light">
             <h3>이송 병원 정보</h3>
             <table>
@@ -187,19 +225,19 @@
           </div>
         </div>
       </div>
-      <footer class="footer">
-        <div class="content has-text-centered">
-          <p>
-            <strong>CodeBLUE</strong> by 항해 14기 챌린지팀 20조. The source
-            code is licensed
-            <a href="http://opensource.org/licenses/mit-license.php">MIT</a>.
-            The website content is licensed
-            <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/"
-              >CC BY NC SA 4.0</a
-            >.
-          </p>
-        </div>
-      </footer>
     </div>
+    <footer class="footer">
+      <div class="content has-text-centered">
+        <p>
+          <strong>CodeBLUE</strong> by 항해 14기 챌린지팀 20조. The source
+          code is licensed
+          <a href="http://opensource.org/licenses/mit-license.php">MIT</a>.
+          The website content is licensed
+          <a href="http://creativecommons.org/licenses/by-nc-sa/4.0/"
+            >CC BY NC SA 4.0</a
+          >.
+        </p>
+      </div>
+    </footer>
   </body>
 </html>

--- a/views/reportDetail.ejs
+++ b/views/reportDetail.ejs
@@ -85,7 +85,7 @@
       </div>
       <div id="navbarBasicExample" class="navbar-menu">
         <div class="navbar-start">
-          <a class="navbar-item" href="/report"> 증상보고서 입력 </a>
+          <a class="navbar-item" href="/symptom-report"> 증상보고서 입력 </a>
           <a class="navbar-item" href="/search"> 증상보고서 검색 </a>
           <div class="navbar-item has-dropdown is-hoverable">
             <a class="navbar-link"> More </a>

--- a/views/reportSearchEngine.ejs
+++ b/views/reportSearchEngine.ejs
@@ -100,7 +100,7 @@
           <p class="title">증상보고서 검색 엔진</p>
           <p class="subtitle">
             <br />
-            현재 <%= count %>개의 누적 증상보고서가 있습니다.
+            현재 2,221,467개의 누적 증상보고서가 있습니다.
             <br />
             보고서 생성 날짜, 증상, 중증도 레벨, 이송 병원 지역, 환자 성명을
             통해 검색해보세요.
@@ -162,7 +162,7 @@
                     id="symptoms"
                     placeholder="증상명"
                     name="symptoms"
-                    style="font-family: 'Noto Sans KR', sans-serif"
+                    style="font-family: 'Noto Sans KR', sans-serif; width: 130px;"
                   />
                 </label>
                 <label for="site" class="form-label select m-5 is-hovered">
@@ -214,7 +214,7 @@
                     id="name"
                     placeholder="환자 성명"
                     name="name"
-                    style="font-family: 'Noto Sans KR', sans-serif"
+                    style="font-family: 'Noto Sans KR', sans-serif; width: 130px;"
                   />
                 </label>
               </div>

--- a/views/reportSearchEngine.ejs
+++ b/views/reportSearchEngine.ejs
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- Favicon -->
-    <link rel="icon" href="./image/codeblue-favicon.png"/> 
-    <link rel="apple-touch-icon" href="./image/codeblue-favicon.png"/>
+    <link rel="icon" href="../../image/codeblue-favicon.png"/> 
+    <link rel="apple-touch-icon" href="../../image/codeblue-favicon.png"/>
 
     <title>CodeBLUE - 증상 보고서 검색 페이지</title>
 
@@ -79,7 +79,7 @@
       </div>
       <div id="navbarBasicExample" class="navbar-menu">
         <div class="navbar-start">
-          <a class="navbar-item" href="/report"> 증상보고서 입력 </a>
+          <a class="navbar-item" href="/symptom-report"> 증상보고서 입력 </a>
           <a class="navbar-item" href="/search"> 증상보고서 검색 </a>
           <div class="navbar-item has-dropdown is-hoverable">
             <a class="navbar-link"> More </a>

--- a/views/searchResult.ejs
+++ b/views/searchResult.ejs
@@ -79,7 +79,7 @@
 
       <div id="navbarBasicExample" class="navbar-menu">
         <div class="navbar-start">
-          <a class="navbar-item" href="/report"> 증상보고서 입력 </a>
+          <a class="navbar-item" href="/symptom-report"> 증상보고서 입력 </a>
           <a class="navbar-item" href="/search"> 증상보고서 검색 </a>
           <div class="navbar-item has-dropdown is-hoverable">
             <a class="navbar-link"> More </a>
@@ -129,6 +129,7 @@
             <div>
               <strong>생성 일자:</strong> <%= `${year}년 ${month}월 ${date}일
               ${hours}시 ${minutes}분` %>
+              <% console.log(searchedData[i]) %>
               <a
                 href="/report/<%=searchedData[i].reports_report_id %>"
                 class="button is-info"


### PR DESCRIPTION
* 증상보고서 입력 url /report와 상세조회 /report/:report_id url이 겹쳐서 상세조회 버튼을 누르는 경우 입력 페이지로 리다이렉트되는 문제를 방지하고자 증상보고서 입력 url을 /symptom-report로 변경하였습니다.
* 증상보고서 상세조회시 report_id로 조회하는 경우 return값이 제대로 넘어오지 않아 repository에서 EXPLAIN index search keyword를 제거해주었습니다.
* 증상보고서 상세조회가 가독성이 떨어져서 table 형식으로 변경해주었습니다.
* 검색엔진에서 count 변수를 넣어주니 페이지 로드 속도가 느려 이를 그냥 하드코딩해주었습니다. 
* 검색엔진에서 화면 사이즈가 줄어들면 증상명, 환자이름 텍스트 상자가 너무 작아져서 이에 width 고정값을 주었습니다.