### PR TITLE
fix: FE 병원조회 & 근처 병원 조회 페이지 버그 수정

### DIFF
--- a/src/hospitals/service/hospitals.service.ts
+++ b/src/hospitals/service/hospitals.service.ts
@@ -240,13 +240,6 @@ export class HospitalsService {
         radius,
       );
     }
-    // else {
-    //   dataSource = await this.hospitalsRepository.getHospitalsWithinRadius(
-    //     37.56615,
-    //     126.97814,
-    //     radius,
-    //   );
-    // }
 
     if (dataSource.length === 0) {
       throw new NotFoundException('해당 반경 내에 병원이 없습니다.');
@@ -265,41 +258,5 @@ export class HospitalsService {
     });
 
     return datas;
-  }
-
-  async calculateRating(
-    hospital,
-    weights: {
-      duration: number;
-      available_beds: number;
-    },
-    maxDuration: number,
-    maxAvailable_beds: number,
-  ) {
-    const durationWeight = weights.duration; //98%
-    const available_bedsWeight = weights.available_beds; //2%
-
-    //duration = 값이 낮을 수록 높은 점수
-    const durationScore = 1 - hospital.duration / maxDuration;
-    //available_beds = 값이 높을 수록 높은 점수
-    const available_bedsScore = hospital.available_beds / maxAvailable_beds;
-    const rating =
-      durationWeight * durationScore +
-      available_bedsWeight * available_bedsScore;
-    return rating;
-  }
-
-  async parseHospitalData(data: string) {
-    const emergencyRoomRegex = /응급실:\s*(\d+(?:\s\/\s\d+)?)/;
-    const surgeryRoomRegex = /수술실:\s*(\d+(?:\s\/\s\d+)?)/;
-    const wardRegex = /입원실:\s*(\d+(?:\s\/\s\d+)?)/;
-    const emergencyRoom = data.match(emergencyRoomRegex);
-    const surgeryRoom = data.match(surgeryRoomRegex);
-    const ward = data.match(wardRegex);
-    return {
-      emergencyRoom: emergencyRoom ? emergencyRoom[1] : '정보없음',
-      surgeryRoom: surgeryRoom ? surgeryRoom[1] : '정보없음',
-      ward: ward ? ward[1] : '정보없음',
-    };
   }
 }

--- a/views/nearbyHospitals.ejs
+++ b/views/nearbyHospitals.ejs
@@ -219,7 +219,7 @@
               </div>
             </div>
             <h6><%=hospitals_data[i].address %></h6>
-            <h6>이동거리: <%=hospitals_data[i].distance %></h6>
+            <h6>이동 거리: <%= `${(parseFloat(hospitals_data[i].distance) / 1000).toFixed(1)}km` %></h6>
           </div>
           <% } %>
         </div>

--- a/views/recommendedHospitals.ejs
+++ b/views/recommendedHospitals.ejs
@@ -423,8 +423,8 @@
               <%=hospitals_data[i].seconds %>
             </h6>
             <h6>이동거리: <%=hospitals_data[i].distance %>km</h6>
-            <div class="columns">
-              <div class="column">실시간 가용병상</div>
+            <div class="columns has-background-white m-1">
+              <div class="column"><strong>실시간 가용병상 ➡️</strong></div>
               <div class="column has-text-danger has-text-weight-bold">
                 응급실: <%=hospitals_data[i].real_time_beds_info.emergencyRoom
                 %>


### PR DESCRIPTION
* unit test 전체 완료하였습니다.
* 병원조회 페이지에서 실시간 가용병상 & 잔여 병상수가 좀 구분돼있으면 좋을 것 같아서 화살표랑 같이 구분해주었습니다.
![image](https://github.com/project-codeblue/CodeBlue/assets/76824986/f4bf8bd4-e3ff-4b4e-a7bd-86c87fffa588)
